### PR TITLE
Update freetype2 submodule URL

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,7 +4,7 @@
     branch = glew-1.13
 [submodule "include/freetype2"]
 	path = include/freetype2
-	url = https://git.savannah.gnu.org/git/freetype/freetype2.git
+	url = https://github.com/freetype/freetype2.git
     branch = 2.6.5
 [submodule "include/openal-soft"]
 	path = include/openal-soft


### PR DESCRIPTION
Update freetype2 submodule URL

The previous URL is no longer functional. This pull request replaces it with a working URL: https://github.com/freetype/freetype2.git

Maintains the existing version (2.6.5) of the submodule to ensure continued compatibility and avoid breaking changes for existing users, although upgrading to a newer freetype2 version would likely not cause problems.
